### PR TITLE
Fix #1 -- Add settings to make the field required and add a help text

### DIFF
--- a/pretix_telephone/__init__.py
+++ b/pretix_telephone/__init__.py
@@ -4,10 +4,10 @@ from django.utils.translation import ugettext_lazy
 
 class PluginApp(AppConfig):
     name = 'pretix_telephone'
-    verbose_name = 'Pretix Telephone Contact Question'
+    verbose_name = 'Pretix Phone Number Field'
 
     class PretixPluginMeta:
-        name = ugettext_lazy('Pretix Telephone Contact Question')
+        name = ugettext_lazy('Pretix Phone Number Field')
         author = 'Felix Rindt'
         description = ugettext_lazy('This plugin adds a contact question asking for the telephone number.')
         visible = True

--- a/pretix_telephone/locale/de/LC_MESSAGES/django.po
+++ b/pretix_telephone/locale/de/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-30 09:26+0100\n"
+"POT-Creation-Date: 2018-05-18 20:38+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Felix Rindt\n"
 "Language-Team: \n"
@@ -10,19 +10,24 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #: pretix_telephone/__init__.py:10
-msgid "Pretix Telephone Contact Question"
-msgstr "Pretix Telefon Kontaktfrage"
+msgid "Pretix Phone Number Field"
+msgstr "pretix Telefonnummernfeld"
 
 #: pretix_telephone/__init__.py:12
 msgid "This plugin adds a contact question asking for the telephone number."
-msgstr "Dieses Plugin fügt eine Kontaktfrage hinzu, die nach der Telefonnummer fragt."
+msgstr ""
+"Dieses Plugin fügt eine Kontaktfrage hinzu, die nach der Telefonnummer fragt."
 
-#: pretix_telephone/signals.py:12 pretix_telephone/signals.py:14
-#: pretix_telephone/templates/pretix_telephone/orderdetails.html:14
-msgid "Telephone"
-msgstr "Telefon"
+#: pretix_telephone/signals.py:16 pretix_telephone/signals.py:19
+msgid "Phone number"
+msgstr "Telefonnummer"
+
+#: pretix_telephone/signals.py:36
+msgid "Phone number field"
+msgstr "Telefonnummern-Feld"
 
 #: pretix_telephone/templates/pretix_telephone/orderdetails.html:7
 msgid "Contact information"
@@ -31,3 +36,41 @@ msgstr "Kontaktinformationen"
 #: pretix_telephone/templates/pretix_telephone/orderdetails.html:12
 msgid "E-Mail"
 msgstr "E-Mail"
+
+#: pretix_telephone/templates/pretix_telephone/orderdetails.html:14
+msgid "Telephone"
+msgstr "Telefon"
+
+#: pretix_telephone/templates/pretix_telephone/settings.html:5
+msgid "Telephone field"
+msgstr "Telefon-Feld"
+
+#: pretix_telephone/templates/pretix_telephone/settings.html:13
+msgid "Save"
+msgstr "Speichern"
+
+#: pretix_telephone/views.py:13
+msgid "Require phone number"
+msgstr "Telefonnummer erforderlich"
+
+#: pretix_telephone/views.py:14
+msgid "If this is not checked, entering a phone number is optional."
+msgstr ""
+"Wenn diese Option nicht aktiv ist, ist die Eingabe einer Telefonnummer "
+"freiwillig."
+
+#: pretix_telephone/views.py:18
+msgid "Help text"
+msgstr "Hilfetext"
+
+#: pretix_telephone/views.py:19
+msgid ""
+"This will be shown below the telephone field. You could use it to indicate "
+"why you need the number or what you will use it for."
+msgstr ""
+"Dieser Text wird unter dem Formularfeld für die Telefonnummer angezeigt. Sie "
+"können hier z.B. erklären warum Sie die Nummer brauchen oder wofür Sie die "
+"Nummer nutzen."
+
+#~ msgid "Pretix Telephone Contact Question"
+#~ msgstr "Pretix Telefon Kontaktfrage"

--- a/pretix_telephone/locale/de_Informal/LC_MESSAGES/django.po
+++ b/pretix_telephone/locale/de_Informal/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-30 09:26+0100\n"
+"POT-Creation-Date: 2018-05-18 20:38+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Felix Rindt\n"
 "Language-Team: \n"
@@ -10,19 +10,24 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #: pretix_telephone/__init__.py:10
-msgid "Pretix Telephone Contact Question"
-msgstr "Pretix Telefon Kontaktfrage"
+msgid "Pretix Phone Number Field"
+msgstr "pretix Telefonnummernfeld"
 
 #: pretix_telephone/__init__.py:12
 msgid "This plugin adds a contact question asking for the telephone number."
-msgstr "Dieses Plugin fügt eine Kontaktfrage hinzu, die nach der Telefonnummer fragt."
+msgstr ""
+"Dieses Plugin fügt eine Kontaktfrage hinzu, die nach der Telefonnummer fragt."
 
-#: pretix_telephone/signals.py:12 pretix_telephone/signals.py:14
-#: pretix_telephone/templates/pretix_telephone/orderdetails.html:14
-msgid "Telephone"
-msgstr "Telefon"
+#: pretix_telephone/signals.py:16 pretix_telephone/signals.py:19
+msgid "Phone number"
+msgstr "Telefonnummer"
+
+#: pretix_telephone/signals.py:36
+msgid "Phone number field"
+msgstr "Telefonnummern-Feld"
 
 #: pretix_telephone/templates/pretix_telephone/orderdetails.html:7
 msgid "Contact information"
@@ -31,3 +36,41 @@ msgstr "Kontaktinformationen"
 #: pretix_telephone/templates/pretix_telephone/orderdetails.html:12
 msgid "E-Mail"
 msgstr "E-Mail"
+
+#: pretix_telephone/templates/pretix_telephone/orderdetails.html:14
+msgid "Telephone"
+msgstr "Telefon"
+
+#: pretix_telephone/templates/pretix_telephone/settings.html:5
+msgid "Telephone field"
+msgstr "Telefon-Feld"
+
+#: pretix_telephone/templates/pretix_telephone/settings.html:13
+msgid "Save"
+msgstr "Speichern"
+
+#: pretix_telephone/views.py:13
+msgid "Require phone number"
+msgstr "Telefonnummer erforderlich"
+
+#: pretix_telephone/views.py:14
+msgid "If this is not checked, entering a phone number is optional."
+msgstr ""
+"Wenn diese Option nicht aktiv ist, ist die Eingabe einer Telefonnummer "
+"freiwillig."
+
+#: pretix_telephone/views.py:18
+msgid "Help text"
+msgstr "Hilfetext"
+
+#: pretix_telephone/views.py:19
+msgid ""
+"This will be shown below the telephone field. You could use it to indicate "
+"why you need the number or what you will use it for."
+msgstr ""
+"Dieser Text wird unter dem Formularfeld für die Telefonnummer angezeigt. Du "
+"kannst hier z.B. erklären warum du die Nummer brauchst oder wofür du die "
+"Nummer nutzt."
+
+#~ msgid "Pretix Telephone Contact Question"
+#~ msgstr "Pretix Telefon Kontaktfrage"

--- a/pretix_telephone/templates/pretix_telephone/settings.html
+++ b/pretix_telephone/templates/pretix_telephone/settings.html
@@ -1,0 +1,17 @@
+{% extends "pretixcontrol/event/settings_base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+{% block inside %}
+    <legend>{% trans "Telephone field" %}</legend>
+    <form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
+        {% csrf_token %}
+        {% bootstrap_form_errors form %}
+        {% bootstrap_field form.telephone_field_required layout="control" %}
+        {% bootstrap_field form.telephone_field_help_text layout="control" %}
+        <div class="form-group submit-group">
+            <button type="submit" class="btn btn-primary btn-save">
+                {% trans "Save" %}
+            </button>
+        </div>
+    </form>
+{% endblock %}

--- a/pretix_telephone/urls.py
+++ b/pretix_telephone/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from .views import TelephoneFieldSettings
+
+urlpatterns = [
+    url(r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/telephone/settings$',
+        TelephoneFieldSettings.as_view(), name='settings'),
+]

--- a/pretix_telephone/views.py
+++ b/pretix_telephone/views.py
@@ -1,0 +1,36 @@
+from django import forms
+from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
+from i18nfield.forms import I18nFormField, I18nTextInput
+
+from pretix.base.forms import SettingsForm
+from pretix.base.models import Event
+from pretix.control.views.event import EventSettingsFormView, EventSettingsViewMixin
+
+
+class TelephoneFieldSettingsForm(SettingsForm):
+    telephone_field_required = forms.BooleanField(
+        label=_("Require phone number"),
+        help_text=_("If this is not checked, entering a phone number is optional."),
+        required=False,
+    )
+    telephone_field_help_text = I18nFormField(
+        label=_("Help text"),
+        help_text=_("This will be shown below the telephone field. You could use it to indicate why you need the "
+                    "number or what you will use it for."),
+        required=False,
+        widget=I18nTextInput
+    )
+
+
+class TelephoneFieldSettings(EventSettingsViewMixin, EventSettingsFormView):
+    model = Event
+    form_class = TelephoneFieldSettingsForm
+    template_name = 'pretix_telephone/settings.html'
+    permission = 'can_change_settings'
+
+    def get_success_url(self) -> str:
+        return reverse('plugins:pretix_telephone:settings', kwargs={
+            'organizer': self.request.event.organizer.slug,
+            'event': self.request.event.slug
+        })


### PR DESCRIPTION
Hi,

for a customer we need a required telephone field with a certain help text, so I figured the best way would be to extend this plugin. On the way, I changed the (English) language slightly, as I think it feels more natural.

Happy for any feedback!

Raphael