### PR TITLE
Do not fail on orders without 'contact_form_data'

### DIFF
--- a/pretix_telephone/signals.py
+++ b/pretix_telephone/signals.py
@@ -32,7 +32,7 @@ def add_telephone_order_info(sender, order=None, **kwargs):
     if not order:
         return
     template = get_template('pretix_telephone/orderdetails.html')
-    ctx = json.loads(order.meta_info)['contact_form_data']
+    ctx = json.loads(order.meta_info).get('contact_form_data', {})
     return template.render(ctx)
 
 


### PR DESCRIPTION
This is the case e.g. for orders created through the API